### PR TITLE
fix: make autoware_cmake Clang-friendly

### DIFF
--- a/autoware_cmake/cmake/autoware_package.cmake
+++ b/autoware_cmake/cmake/autoware_package.cmake
@@ -23,9 +23,38 @@ macro(autoware_package)
     add_compile_options(-Wall -Wextra -Wpedantic -Werror)
   endif()
 
-  # Ignore PCL errors in Clang
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # Ignore PCL errors in Clang
     add_compile_options(-Wno-gnu-anonymous-struct -Wno-nested-anon-types)
+
+    # Flag unknown (e.g. GNU-specific) options, but do not fail compilation
+    add_compile_options(-Wno-error=unknown-warning-option)
+
+    # temporary
+    add_compile_options(
+      # Iteration 1
+      -Wno-error=delete-non-abstract-non-virtual-dtor
+      -Wno-error=delete-abstract-non-virtual-dtor
+      -Wno-error=deprecated-copy
+      -Wno-error=c11-extensions
+      -Wno-error=unused-but-set-variable
+      -Wno-error=unused-private-field
+      -Wno-error=infinite-recursion
+      -Wno-error=implicit-const-int-float-conversion
+      -Wno-error=unused-lambda-capture
+      -Wno-error=unused-const-variable
+      #Iteration 2
+      -Wno-error=deprecated-builtins
+      -Wno-error=format-security
+      -Wno-error=inconsistent-missing-override
+      -Wno-error=overloaded-virtual
+      -Wno-error=pessimizing-move
+      -Wno-error=sign-conversion
+      -Wno-error=unused-function
+      #Iteration 3
+      -Wno-error=defaulted-function-deleted
+      -Wno-error=unused-parameter
+    )
   endif()
 
   # Ignore Boost deprecated messages


### PR DESCRIPTION
## Description

Demote some errors output by Clang to warning in order to make Autoware Clang-friendly.

```shell
colcon build 2>&1 | tee build.log
cat build.log | grep -oP '\[-Werror,\K[^]]*' | sort | uniq -c
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
