### PR TITLE
fix(docker-build-and-push*.yaml): use `step-security/changed-files` action insteaduse step-security

### DIFF
--- a/.github/workflows/build-and-test-differential.yaml
+++ b/.github/workflows/build-and-test-differential.yaml
@@ -75,5 +75,42 @@ jobs:
           verbose: true
           flags: differential
 
+<<<<<<< Updated upstream
       - name: Show disk space after the tasks
         run: df -h
+=======
+  clang-tidy-differential:
+    runs-on: ubuntu-latest
+    container: ros:humble
+    needs: build-and-test-differential
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Remove exec_depend
+        uses: autowarefoundation/autoware-github-actions/remove-exec-depend@v1
+
+      - name: Get modified packages
+        id: get-modified-packages
+        uses: autowarefoundation/autoware-github-actions/get-modified-packages@v1
+
+      - name: Get modified files
+        id: get-modified-files
+        uses: step-security/changed-files@v42
+        with:
+          files: |
+            **/*.cpp
+            **/*.hpp
+
+      - name: Run clang-tidy
+        if: ${{ steps.get-modified-files.outputs.all_changed_files != '' }}
+        uses: autowarefoundation/autoware-github-actions/clang-tidy@v1
+        with:
+          rosdistro: humble
+          target-packages: ${{ steps.get-modified-packages.outputs.modified-packages }}
+          target-files: ${{ steps.get-modified-files.outputs.all_changed_files }}
+          clang-tidy-config-url: https://raw.githubusercontent.com/autowarefoundation/autoware/main/.clang-tidy
+          build-depends-repos: build_depends.repos
+>>>>>>> Stashed changes


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware/pull/5890 for this repository.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
