### PR TITLE
fix(autoware_package.cmake): workaround to avoid `missing tinyxml2::tinyxml2`

### DIFF
--- a/autoware_cmake/cmake/autoware_package.cmake
+++ b/autoware_cmake/cmake/autoware_package.cmake
@@ -61,6 +61,22 @@ macro(autoware_package)
     )
   endif()
 
+  # TODO(youtalk): Remove this workaround once https://github.com/autowarefoundation/autoware_universe/issues/10410 is fixed
+  find_package(TinyXML2 CONFIG QUIET)
+  if(NOT TinyXML2_FOUND)
+    find_path(TINYXML2_INCLUDE_DIR NAMES tinyxml2.h)
+    find_library(TINYXML2_LIBRARY tinyxml2)
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(TinyXML2 DEFAULT_MSG TINYXML2_LIBRARY TINYXML2_INCLUDE_DIR)
+    mark_as_advanced(TINYXML2_INCLUDE_DIR TINYXML2_LIBRARY)
+    if(NOT TARGET tinyxml2::tinyxml2)
+      add_library(tinyxml2::tinyxml2 UNKNOWN IMPORTED)
+      set_property(TARGET tinyxml2::tinyxml2 PROPERTY IMPORTED_LOCATION ${TINYXML2_LIBRARY})
+      set_property(TARGET tinyxml2::tinyxml2 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${TINYXML2_INCLUDE_DIR})
+      list(APPEND TinyXML2_TARGETS tinyxml2::tinyxml2)
+    endif()
+  endif()
+
   # Find test dependencies
   if(BUILD_TESTING)
     find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
## Description

This PR is a workaround for  https://github.com/autowarefoundation/autoware_universe/issues/10410. Since I found out that we need to modify many `CMakeLists.txt` files in `autoware_universe`, I decided to solve it in `autoware_cmake` instead.

## How was this PR tested?

- https://github.com/youtalk/autoware/pull/190
- https://github.com/youtalk/autoware/actions/runs/14323230398/job/40143989942?pr=190

## Notes for reviewers

None.

## Effects on system behavior

None.
