### PR TITLE
feat(autoware_cmake): allow deprecated-declarations

### DIFF
--- a/autoware_cmake/cmake/autoware_package.cmake
+++ b/autoware_cmake/cmake/autoware_package.cmake
@@ -20,7 +20,7 @@ macro(autoware_package)
     set(CMAKE_CXX_EXTENSIONS OFF)
   endif()
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+    add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-error=deprecated-declarations)
   endif()
 
   # Ignore PCL errors in Clang


### PR DESCRIPTION
## Description

Currently `[[deprecated]]` causes an error due to `-Werror` option. But this is important for the interface transition, so allow it.

## How was this PR tested?

None

## Notes for reviewers

None.

## Effects on system behavior

None.
