### PR TITLE
feat: create autoware_interface_check package

### DIFF
--- a/autoware_cmake_interface_check/CMakeLists.txt
+++ b/autoware_cmake_interface_check/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(autoware_cmake_interface_check NONE)
+
+find_package(ament_cmake_core REQUIRED)
+find_package(ament_cmake_test REQUIRED)
+
+ament_package(
+  CONFIG_EXTRAS "autoware_cmake_interface_check-extras.cmake"
+)
+
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_copyright REQUIRED)
+  find_package(ament_cmake_lint_cmake REQUIRED)
+  ament_copyright()
+  ament_lint_cmake()
+endif()

--- a/autoware_cmake_interface_check/README.md
+++ b/autoware_cmake_interface_check/README.md
@@ -1,0 +1,3 @@
+# autoware_cmake_interface_check
+
+This package provides CMake scripts for interface check.

--- a/autoware_cmake_interface_check/README.md
+++ b/autoware_cmake_interface_check/README.md
@@ -1,3 +1,20 @@
 # autoware_cmake_interface_check
 
-This package provides CMake scripts for interface check.
+This package provides colcon test integration for [autoware_interface_check](../autoware_interface_check/README.md).
+
+## Usage
+
+Add the following to package.xml.
+
+```xml
+<test_depend>autoware_cmake_interface_check</test_depend>
+```
+
+Add the following to CMakeLists.txt.
+
+```cmake
+if(BUILD_TESTING)
+  find_package(autoware_cmake_interface_check REQUIRED)
+  autoware_interface_check("test/autoware_interface_check.yaml")
+endif()
+```

--- a/autoware_cmake_interface_check/autoware_cmake_interface_check-extras.cmake
+++ b/autoware_cmake_interface_check/autoware_cmake_interface_check-extras.cmake
@@ -1,0 +1,16 @@
+# Copyright 2025 The Autoware Contributors
+# Copyright 2014-2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include("${autoware_cmake_interface_check_DIR}/autoware_interface_check.cmake")

--- a/autoware_cmake_interface_check/cmake/autoware_interface_check.cmake
+++ b/autoware_cmake_interface_check/cmake/autoware_interface_check.cmake
@@ -1,0 +1,57 @@
+# Copyright 2025 The Autoware Contributors
+# Copyright 2014-2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function(autoware_interface_check)
+
+  # Parse arguments and set default value.
+  cmake_parse_arguments(ARG "" "TESTNAME;TIMEOUT" "" ${ARGN})
+  if(NOT ARG_TESTNAME)
+    set(ARG_TESTNAME "autoware_interface_check")
+  endif()
+  if(NOT ARG_TIMEOUT)
+    set(ARG_TIMEOUT 500)
+  endif()
+
+  # Find check tool.
+  find_program(autoware_interface_check_BIN NAMES "autoware-interface-check")
+  if(NOT autoware_interface_check_BIN)
+    message(FATAL_ERROR "autoware_interface_check() could not find program 'autoware-interface-check'")
+  endif()
+
+  # Set test configurations.
+  set(result_file "${AMENT_TEST_RESULTS_DIR}/${PROJECT_NAME}/${ARG_TESTNAME}.xunit.xml")
+  set(result_name "${PROJECT_NAME}.${ARG_TESTNAME}")
+  set(output_file "${CMAKE_BINARY_DIR}/autoware_interface_check/${ARG_TESTNAME}.txt")
+  file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/autoware_interface_check")
+
+  # Set test command.
+  set(cmd "${autoware_interface_check_BIN}" "--xunit-file" "${result_file}" "--xunit-name" "${result_name}")
+  list(APPEND cmd ${ARG_UNPARSED_ARGUMENTS})
+
+  ament_add_test(
+    "${ARG_TESTNAME}"
+    COMMAND ${cmd}
+    OUTPUT_FILE "${output_file}"
+    RESULT_FILE "${result_file}"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    TIMEOUT "${ARG_TIMEOUT}"
+  )
+  set_tests_properties(
+    "${ARG_TESTNAME}"
+    PROPERTIES
+    LABELS "autoware_interface_check"
+  )
+
+endfunction()

--- a/autoware_cmake_interface_check/cmake/autoware_interface_check.cmake
+++ b/autoware_cmake_interface_check/cmake/autoware_interface_check.cmake
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# cspell:ignore ARGN, TESTNAME
+
 function(autoware_interface_check)
 
   # Parse arguments and set default value.

--- a/autoware_cmake_interface_check/package.xml
+++ b/autoware_cmake_interface_check/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_cmake_interface_check</name>
+  <version>0.0.0</version>
+  <description>CMake scripts for interface check</description>
+  <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_core</buildtool_depend>
+  <buildtool_depend>ament_cmake_test</buildtool_depend>
+
+  <buildtool_export_depend>ament_cmake_test</buildtool_export_depend>
+  <buildtool_export_depend>autoware_interface_check</buildtool_export_depend>
+
+  <test_depend>ament_cmake_copyright</test_depend>
+  <test_depend>ament_cmake_lint_cmake</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/autoware_interface_check/README.md
+++ b/autoware_interface_check/README.md
@@ -1,0 +1,19 @@
+# autoware_interface_check
+
+This package provides tools to checking Autoware interfaces.
+
+- param-check
+
+# Usage
+
+Create a test specification file like this.
+Please see here For more information on the file format,
+
+```yaml
+```
+
+Run
+
+```bash
+$
+```

--- a/autoware_interface_check/README.md
+++ b/autoware_interface_check/README.md
@@ -4,17 +4,44 @@ This package provides tools to checking Autoware interfaces.
 
 - param-check
 
-# Usage
+## Usage
 
-Create a test specification file like this.
-Please see here For more information on the file format,
+The following steps are required to run the test:
 
-```yaml
+1. Create a test definition file such as [example/interface.yaml](./example/interface.yaml).
+2. Run the check command using the above test definition file.
 
-```
-
-Run
+## Command
 
 ```bash
-$
+autoware-interface-check test-definition-file
+```
+
+| Argument             | Type   | Description                                              |
+| -------------------- | ------ | -------------------------------------------------------- |
+| test-definition-file | string | Path of test definition file.                            |
+| --xunit-file         | string | File path of xUnit. This is for colcon test integration. |
+| --xunit-name         | string | Test name of xUnit. This is for colcon test integration. |
+
+## Example
+
+```txt
+$ autoware-interface-check src/core/autoware_cmake/autoware_interface_check/example/interface.yaml
+Test #0 (Success)
+  message: OK
+  details:
+    schema: /home/user-name/autoware/install/autoware_interface_check/share/autoware_interface_check/example/schema/foo.schema.json
+    params: /home/user-name/autoware/install/autoware_interface_check/share/autoware_interface_check/example/config/foo_success.param.yaml
+
+Test #1 (Failure)
+  message: 'frame' is a required property
+  details:
+    schema: /home/user-name/autoware/install/autoware_interface_check/share/autoware_interface_check/example/schema/foo.schema.json
+    params: /home/user-name/autoware/install/autoware_interface_check/share/autoware_interface_check/example/config/foo_failure.param.yaml
+
+Summary
+  all    : 2
+  success: 1
+  failure: 1
+  errors : 0
 ```

--- a/autoware_interface_check/README.md
+++ b/autoware_interface_check/README.md
@@ -10,6 +10,7 @@ Create a test specification file like this.
 Please see here For more information on the file format,
 
 ```yaml
+
 ```
 
 Run

--- a/autoware_interface_check/autoware_interface_check/common/case.py
+++ b/autoware_interface_check/autoware_interface_check/common/case.py
@@ -1,0 +1,69 @@
+# Copyright 2025 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+from pathlib import Path
+
+import yaml
+
+
+class TestStatus(Enum):
+    Null = 0
+    Success = 1
+    Failure = 2
+    Error = 3
+    Skipped = 4
+
+
+class TestResult:
+    def __init__(self, status, message, details):
+        self.status = status
+        self.message = message
+        self.details = details
+
+    @staticmethod
+    def Success(message="", details=""):
+        return TestResult(TestStatus.Success, message, details)
+
+    @staticmethod
+    def Failure(message="", details=""):
+        return TestResult(TestStatus.Failure, message, details)
+
+    @staticmethod
+    def Error(message="", details=""):
+        return TestResult(TestStatus.Error, message, details)
+
+
+class TestCase:
+    def __init__(self, data):
+        self.data = data
+        self.result = TestResult(TestStatus.Null, "", "")
+
+
+class TestSuite:
+    def __init__(self, cases):
+        self.cases = cases
+
+    def count(self, status=None):
+        if status is None:
+            return len(self.cases)
+        else:
+            return sum(1 for case in self.cases if case.result.status == status)
+
+    @staticmethod
+    def Load(path: Path | str):
+        path = Path(path) if type(path) is str else path
+        with path.open() as fp:
+            suite = yaml.safe_load(fp)
+        return TestSuite([TestCase(data) for data in suite.get("param-checks", [])])

--- a/autoware_interface_check/autoware_interface_check/common/path.py
+++ b/autoware_interface_check/autoware_interface_check/common/path.py
@@ -1,0 +1,39 @@
+# Copyright 2025 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
+
+
+class FilePath:
+    def __init__(self, path):
+        self.path = path
+
+    def __str__(self):
+        return str(self.path)
+
+    @staticmethod
+    def Parse(data: dict):
+        # package not found
+        file = data.get("file")
+        if file is None:
+            # throw ParseError
+            return None
+        pkg = data.get("package")
+        if pkg is None:
+            return FilePath(Path(file))
+        else:
+            pkg = get_package_share_directory(pkg)
+            return FilePath(Path(pkg) / Path(file))

--- a/autoware_interface_check/autoware_interface_check/entrypoint.py
+++ b/autoware_interface_check/autoware_interface_check/entrypoint.py
@@ -1,0 +1,91 @@
+# Copyright 2025 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import textwrap
+import time
+import xml.dom.minidom as MD
+import xml.etree.ElementTree as ET
+import xml.sax.saxutils as sax
+
+from .common.case import TestStatus
+from .common.case import TestSuite
+from . import param
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("target")
+    parser.add_argument("--xunit-file")
+    parser.add_argument("--xunit-name")
+    args = parser.parse_args()
+
+    start = time.time()
+
+    suite = TestSuite.Load(args.target)
+    for case in suite.cases:
+        case.result = param.check(case.data)
+
+    duration = time.time() - start
+
+    for index, case in enumerate(suite.cases):
+        print(f"Test #{index} ({case.result.status.name})")
+        print("  message:", case.result.message)
+        print("  details:")
+        print(textwrap.indent(format_details(case.result.details), "    "))
+        print()
+
+    print("Summary")
+    print("  all    :", suite.count())
+    print("  success:", suite.count(TestStatus.Success))
+    print("  failure:", suite.count(TestStatus.Failure))
+    print("  errors :", suite.count(TestStatus.Error))
+
+    if args.xunit_file:
+        path = args.xunit_file
+        name = args.xunit_name
+        generate_xunit(path, suite, name, duration)
+
+
+def generate_xunit(path, suite, name, duration):
+    root = ET.Element("testsuite")
+    root.set("name", name)
+    root.set("tests", str(suite.count()))
+    root.set("errors", str(suite.count(TestStatus.Error)))
+    root.set("failures", str(suite.count(TestStatus.Failure)))
+    root.set("time", f"{duration:.3f}")
+
+    for index, case in enumerate(suite.cases):
+        item = ET.SubElement(root, "testcase")
+        item.set("name", f"Test #{index}")
+        item.set("classname", name)
+
+        if case.result.status == TestStatus.Failure:
+            info = ET.SubElement(item, "failure")
+            info.set("message", sax.quoteattr(case.result.message))
+            info.text = sax.escape(format_details(case.result.details))
+
+        if case.result.status == TestStatus.Error:
+            info = ET.SubElement(item, "error")
+            info.set("message", sax.quoteattr(case.result.message))
+            info.text = sax.escape(format_details(case.result.details))
+
+    with open(path, "w") as fp:
+        xml = MD.parseString(ET.tostring(root, "UTF-8"))
+        xml.writexml(fp, encoding="UTF-8", newl="\n", addindent="  ")
+
+
+# Temporary
+def format_details(details):
+    return "\n".join(f"{key}: {value}" for key, value in details)

--- a/autoware_interface_check/autoware_interface_check/entrypoint.py
+++ b/autoware_interface_check/autoware_interface_check/entrypoint.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# cspell:ignore addindent, newl
+
 import argparse
 import textwrap
 import time

--- a/autoware_interface_check/autoware_interface_check/param.py
+++ b/autoware_interface_check/autoware_interface_check/param.py
@@ -1,0 +1,46 @@
+# Copyright 2025 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import jsonschema
+import yaml
+
+from .common.case import TestResult
+from .common.path import FilePath
+
+
+def validate(schema_path, params_path):
+    details = (
+        ("schema", str(schema_path)),
+        ("params", str(params_path)),
+    )
+    with schema_path.path.open() as fp:
+        schema = json.load(fp)
+    with params_path.path.open() as fp:
+        target = yaml.safe_load(fp)
+    try:
+        jsonschema.validate(target, schema)
+        return TestResult.Success("OK", details)
+    except jsonschema.ValidationError as error:
+        return TestResult.Failure(error.message, details)
+
+
+def check(data: dict):
+    try:
+        schema = FilePath.Parse(data["schema"])
+        params = FilePath.Parse(data["params"])
+        return validate(schema, params)
+    except Exception as error:
+        return TestResult.Error(repr(error), "")

--- a/autoware_interface_check/example/config/foo_failure.param.yaml
+++ b/autoware_interface_check/example/config/foo_failure.param.yaml
@@ -1,0 +1,3 @@
+/**:
+  ros__parameters:
+    angle: 0.0

--- a/autoware_interface_check/example/config/foo_success.param.yaml
+++ b/autoware_interface_check/example/config/foo_success.param.yaml
@@ -1,0 +1,4 @@
+/**:
+  ros__parameters:
+    angle: 0.0
+    frame: map

--- a/autoware_interface_check/example/interface.yaml
+++ b/autoware_interface_check/example/interface.yaml
@@ -1,0 +1,14 @@
+param-checks:
+  - schema:
+      package: autoware_interface_check
+      file: example/schema/foo.schema.json
+    params:
+      package: autoware_interface_check
+      file: example/config/foo_success.param.yaml
+
+  - schema:
+      package: autoware_interface_check
+      file: example/schema/foo.schema.json
+    params:
+      package: autoware_interface_check
+      file: example/config/foo_failure.param.yaml

--- a/autoware_interface_check/example/schema/foo.schema.json
+++ b/autoware_interface_check/example/schema/foo.schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "The foo node parameters",
+  "type": "object",
+  "definitions": {
+    "foo_node": {
+      "type": "object",
+      "properties": {
+        "angle": {
+          "type": "number",
+          "default": 0.0,
+          "minimum": 0.0,
+          "maximum": 360.0
+        },
+        "frame": {
+          "type": "string"
+        }
+      },
+      "required": ["angle", "frame"]
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/foo_node"
+        }
+      },
+      "required": ["ros__parameters"]
+    }
+  },
+  "required": ["/**"]
+}

--- a/autoware_interface_check/package.xml
+++ b/autoware_interface_check/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_interface_check</name>
+  <version>0.0.0</version>
+  <description>Tools for interface check</description>
+  <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
+  <license>Apache License 2.0</license>
+
+  <exec_depend>ament_index_python</exec_depend>
+  <exec_depend>python3-jsonschema</exec_depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/autoware_interface_check/setup.py
+++ b/autoware_interface_check/setup.py
@@ -1,0 +1,32 @@
+from warnings import simplefilter
+
+from pkg_resources import PkgResourcesDeprecationWarning
+from setuptools import SetuptoolsDeprecationWarning
+from setuptools import setup
+
+simplefilter("ignore", category=SetuptoolsDeprecationWarning)
+simplefilter("ignore", category=PkgResourcesDeprecationWarning)
+
+package_name = "autoware_interface_check"
+
+setup(
+    name=package_name,
+    version="0.47.0",
+    packages=[package_name],
+    data_files=[
+        ("share/ament_index/resource_index/packages", [f"resource/{package_name}"]),
+        (f"share/{package_name}", ["package.xml"]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="Takagi, Isamu",
+    maintainer_email="isamu.takagi@tier4.jp",
+    description="Tools for interface check",
+    license="Apache License 2.0",
+    tests_require=["pytest", "jsonschema"],
+    entry_points={
+        "console_scripts": [
+            "autoware-interface-check = autoware_interface_check.entrypoint:main",
+        ]
+    },
+)

--- a/autoware_interface_check/setup.py
+++ b/autoware_interface_check/setup.py
@@ -1,3 +1,4 @@
+from glob import glob
 from warnings import simplefilter
 
 from pkg_resources import PkgResourcesDeprecationWarning
@@ -16,6 +17,8 @@ setup(
     data_files=[
         ("share/ament_index/resource_index/packages", [f"resource/{package_name}"]),
         (f"share/{package_name}", ["package.xml"]),
+        (f"share/{package_name}/example/config", glob("example/config/*")),
+        (f"share/{package_name}/example/schema", glob("example/schema/*")),
     ],
     install_requires=["setuptools"],
     zip_safe=True,

--- a/autoware_interface_check/test/test_copyright.py
+++ b/autoware_interface_check/test/test_copyright.py
@@ -1,0 +1,25 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.main import main
+import pytest
+
+
+# Remove the `skip` decorator once the source file(s) have a copyright header
+@pytest.mark.skip(reason="No copyright header has been placed in the generated source file.")
+@pytest.mark.copyright
+@pytest.mark.linter
+def test_copyright():
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found errors"

--- a/autoware_interface_check/test/test_pep257.py
+++ b/autoware_interface_check/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2015 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=[".", "test"])
+    assert rc == 0, "Found code style errors / warnings"


### PR DESCRIPTION
## Description

Add cmake test package to validate parameter file using JSON schema parameter definition.
This is expected to improve the issue of Autoware not starting due to parameter mismatch.
See https://github.com/orgs/autowarefoundation/discussions/6442 for details.

## How was this PR tested?

See the sample result on https://github.com/orgs/autowarefoundation/discussions/6442

## Notes for reviewers

None.

## Effects on system behavior

None.
