### PR TITLE
feat: add autoware_ament_auto_package() macro

### DIFF
--- a/autoware_cmake/README.md
+++ b/autoware_cmake/README.md
@@ -15,5 +15,47 @@ project(package_name)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
-ament_auto_add_library(...)
+ ament_auto_add_library(...)
 ```
+
+### autoware_ament_auto_package.cmake
+
+Use `autoware_ament_auto_package()` as a replacement for `ament_auto_package()` to maintain Autoware's include structure across ROS 2 Humble, Jazzy, and Kilted.
+
+This macro addresses a naming convention conflict between Autoware packages (which use `autoware_<module>` as package names) and Autoware include paths (which use `autoware/<module>/`). Starting with ROS 2 Kilted, `ament_auto_package()` will install headers to `include/${PROJECT_NAME}/`, which would create incorrect paths like `include/autoware_interpolation/autoware/interpolation/`.
+
+#### Why use this?
+
+- **Eliminates deprecation warnings** on ROS 2 Humble and Jazzy
+- **Future-proof**: Works with ROS 2 Kilted+ without breaking changes
+- **Maintains conventions**: Preserves `autoware/<module>/` include structure
+- **Drop-in replacement**: Zero behavior change from `ament_auto_package()`
+
+#### Example
+
+```cmake
+cmake_minimum_required(VERSION 3.14)
+project(autoware_interpolation)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+ament_auto_add_library(autoware_interpolation SHARED
+  src/linear_interpolation.cpp
+  src/spline_interpolation.cpp
+)
+
+if(BUILD_TESTING)
+  # ... tests ...
+endif()
+
+# Use autoware_ament_auto_package() instead of ament_auto_package()
+autoware_ament_auto_package()
+```
+
+#### Migration from ament_auto_package()
+
+Simply replace `ament_auto_package()` with `autoware_ament_auto_package()` at the end of your `CMakeLists.txt`. All parameters supported by `ament_auto_package()` are also supported:
+
+- `INSTALL_TO_PATH`: Install executables to `bin/` instead of `lib/${PROJECT_NAME}/`
+- `INSTALL_TO_SHARE`: Install additional directories to `share/${PROJECT_NAME}/`

--- a/autoware_cmake/README.md
+++ b/autoware_cmake/README.md
@@ -15,7 +15,7 @@ project(package_name)
 find_package(autoware_cmake REQUIRED)
 autoware_package()
 
- ament_auto_add_library(...)
+ament_auto_add_library(...)
 ```
 
 ### autoware_ament_auto_package.cmake

--- a/autoware_cmake/autoware_cmake-extras.cmake
+++ b/autoware_cmake/autoware_cmake-extras.cmake
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 include("${autoware_cmake_DIR}/autoware_package.cmake")
+include("${autoware_cmake_DIR}/autoware_ament_auto_package.cmake")

--- a/autoware_cmake/cmake/autoware_ament_auto_package.cmake
+++ b/autoware_cmake/cmake/autoware_ament_auto_package.cmake
@@ -1,4 +1,4 @@
-# Copyright 2024 The Autoware Contributors
+# Copyright 2025 The Autoware Contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,48 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#.rst:
-# autoware_ament_auto_package
-# ---------------------------
-#
-# Replacement for ament_auto_package() that maintains Autoware's include structure
-# across ROS 2 Humble, Jazzy, and Kilted.
-#
-# This macro replicates ament_auto_package() functionality but uses explicit
-# header installation to avoid the deprecation warning and ensure consistent
-# behavior across all ROS 2 distributions.
-#
-# Background:
-# - Autoware uses a naming convention where package names have 'autoware_' prefix
-#   (e.g., autoware_interpolation) but include paths do not (e.g., autoware/interpolation/)
-# - ROS 2 Kilted will change ament_auto_package() to install headers to
-#   include/${PROJECT_NAME}/, which would result in include/autoware_interpolation/autoware/interpolation/
-# - This macro ensures headers are always installed to include/ maintaining the
-#   current structure: include/autoware/interpolation/
-#
-# Usage:
-#   Replace ament_auto_package() with autoware_ament_auto_package() at the end of CMakeLists.txt
-#
-# Example:
-#   cmake_minimum_required(VERSION 3.14)
-#   project(autoware_interpolation)
-#
-#   find_package(autoware_cmake REQUIRED)
-#   autoware_package()
-#
-#   ament_auto_add_library(autoware_interpolation SHARED
-#     src/file1.cpp
-#     src/file2.cpp
-#   )
-#
-#   if(BUILD_TESTING)
-#     # ... tests ...
-#   endif()
-#
-#   autoware_ament_auto_package()  # Instead of ament_auto_package()
-#
-# @public
 
 macro(autoware_ament_auto_package)
   cmake_parse_arguments(_ARG_AUTOWARE_AMENT_AUTO_PACKAGE

--- a/autoware_cmake/cmake/autoware_ament_auto_package.cmake
+++ b/autoware_cmake/cmake/autoware_ament_auto_package.cmake
@@ -1,0 +1,125 @@
+# Copyright 2024 The Autoware Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#.rst:
+# autoware_ament_auto_package
+# ---------------------------
+#
+# Replacement for ament_auto_package() that maintains Autoware's include structure
+# across ROS 2 Humble, Jazzy, and Kilted.
+#
+# This macro replicates ament_auto_package() functionality but uses explicit
+# header installation to avoid the deprecation warning and ensure consistent
+# behavior across all ROS 2 distributions.
+#
+# Background:
+# - Autoware uses a naming convention where package names have 'autoware_' prefix
+#   (e.g., autoware_interpolation) but include paths do not (e.g., autoware/interpolation/)
+# - ROS 2 Kilted will change ament_auto_package() to install headers to
+#   include/${PROJECT_NAME}/, which would result in include/autoware_interpolation/autoware/interpolation/
+# - This macro ensures headers are always installed to include/ maintaining the
+#   current structure: include/autoware/interpolation/
+#
+# Usage:
+#   Replace ament_auto_package() with autoware_ament_auto_package() at the end of CMakeLists.txt
+#
+# Example:
+#   cmake_minimum_required(VERSION 3.14)
+#   project(autoware_interpolation)
+#
+#   find_package(autoware_cmake REQUIRED)
+#   autoware_package()
+#
+#   ament_auto_add_library(autoware_interpolation SHARED
+#     src/file1.cpp
+#     src/file2.cpp
+#   )
+#
+#   if(BUILD_TESTING)
+#     # ... tests ...
+#   endif()
+#
+#   autoware_ament_auto_package()  # Instead of ament_auto_package()
+#
+# @public
+
+macro(autoware_ament_auto_package)
+  cmake_parse_arguments(_ARG_AUTOWARE_AMENT_AUTO_PACKAGE
+    "INSTALL_TO_PATH"
+    ""
+    "INSTALL_TO_SHARE"
+    ${ARGN})
+
+  # Export all found build dependencies which are also run dependencies
+  set(_run_depends
+    ${${PROJECT_NAME}_BUILD_EXPORT_DEPENDS}
+    ${${PROJECT_NAME}_BUILDTOOL_EXPORT_DEPENDS}
+    ${${PROJECT_NAME}_EXEC_DEPENDS})
+  foreach(_dep
+      ${${PROJECT_NAME}_FOUND_BUILD_DEPENDS}
+      ${${PROJECT_NAME}_FOUND_BUILDTOOL_DEPENDS})
+    if(_dep IN_LIST _run_depends)
+      ament_export_dependencies("${_dep}")
+    endif()
+  endforeach()
+
+  # Export and install include directory maintaining Autoware structure
+  # Always use "include" as destination (not "include/${PROJECT_NAME}")
+  # to maintain Autoware's naming convention across all ROS 2 versions
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
+    ament_export_include_directories("include")
+    install(DIRECTORY include/ DESTINATION include
+      FILES_MATCHING
+      PATTERN "*.h"
+      PATTERN "*.hpp"
+      PATTERN "*.hh"
+      PATTERN "*.hxx"
+    )
+  endif()
+
+  # Export and install all libraries
+  if(NOT ${PROJECT_NAME}_LIBRARIES STREQUAL "")
+    ament_export_libraries(${${PROJECT_NAME}_LIBRARIES})
+    install(
+      TARGETS ${${PROJECT_NAME}_LIBRARIES}
+      ARCHIVE DESTINATION lib
+      LIBRARY DESTINATION lib
+      RUNTIME DESTINATION bin
+    )
+  endif()
+
+  # Install executables
+  if(NOT ${PROJECT_NAME}_EXECUTABLES STREQUAL "")
+    if(_ARG_AUTOWARE_AMENT_AUTO_PACKAGE_INSTALL_TO_PATH)
+      set(_executable_destination "bin")
+    else()
+      set(_executable_destination "lib/${PROJECT_NAME}")
+    endif()
+    install(
+      TARGETS ${${PROJECT_NAME}_EXECUTABLES}
+      DESTINATION ${_executable_destination}
+    )
+  endif()
+
+  # Install additional directories to share
+  foreach(_dir ${_ARG_AUTOWARE_AMENT_AUTO_PACKAGE_INSTALL_TO_SHARE})
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${_dir}")
+      install(DIRECTORY "${_dir}/" DESTINATION "share/${PROJECT_NAME}/${_dir}")
+    endif()
+  endforeach()
+
+  # Call ament_package with any unparsed arguments
+  set(_unparsed_args ${_ARG_AUTOWARE_AMENT_AUTO_PACKAGE_UNPARSED_ARGUMENTS})
+  ament_package(${_unparsed_args})
+endmacro()

--- a/autoware_cmake/cmake/autoware_ament_auto_package.cmake
+++ b/autoware_cmake/cmake/autoware_ament_auto_package.cmake
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 macro(autoware_ament_auto_package)
+  # cSpell:ignore ARGN
   cmake_parse_arguments(_ARG_AUTOWARE_AMENT_AUTO_PACKAGE
     "INSTALL_TO_PATH"
     ""


### PR DESCRIPTION
Related #36

## Description

This PR adds a new `autoware_ament_auto_package()` CMake macro that maintains Autoware's include structure (`autoware/<module>/`) across ROS 2 Humble, Jazzy, and Kilted+.

The macro addresses a naming convention conflict between Autoware packages (which use `autoware_<module>` as package names) and Autoware include paths (which use `autoware/<module>/`). Starting with ROS 2 Kilted, `ament_auto_package()` will install headers to `include/${PROJECT_NAME}/`, which would create incorrect paths like `include/autoware_interpolation/autoware/interpolation/`.

## How was this PR tested?

Using the fixed `autoware_cmake`, I built `autoware_core` on ROS 2 Humble and confirmed that the relevant error log no longer appears.

## Notes for reviewers

None.

## Effects on system behavior

None.
