### PR TITLE
[WIP] fix(autoware_ament_auto_package): use scoped header install destination

### DIFF
--- a/autoware_cmake/cmake/autoware_ament_auto_package.cmake
+++ b/autoware_cmake/cmake/autoware_ament_auto_package.cmake
@@ -38,7 +38,7 @@ macro(autoware_ament_auto_package)
   # to maintain Autoware's naming convention across all ROS 2 versions
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
     ament_export_include_directories("include")
-    install(DIRECTORY include/ DESTINATION include
+    install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME}
       FILES_MATCHING
       PATTERN "*.h"
       PATTERN "*.hpp"


### PR DESCRIPTION
## Description

TBD

backport of https://github.com/ament/ament_cmake/pull/540

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

The headers install location will be changed. 
