### PR TITLE
feat(autoware_cmake): support USE_SCOPED_HEADER_INSTALL_DIR in autoware_ament_auto_package

### DIFF
--- a/autoware_cmake/cmake/autoware_ament_auto_package.cmake
+++ b/autoware_cmake/cmake/autoware_ament_auto_package.cmake
@@ -15,7 +15,7 @@
 macro(autoware_ament_auto_package)
   # cSpell:ignore ARGN
   cmake_parse_arguments(_ARG_AUTOWARE_AMENT_AUTO_PACKAGE
-    "INSTALL_TO_PATH"
+    "INSTALL_TO_PATH;USE_SCOPED_HEADER_INSTALL_DIR"
     ""
     "INSTALL_TO_SHARE"
     ${ARGN})
@@ -33,18 +33,29 @@ macro(autoware_ament_auto_package)
     endif()
   endforeach()
 
-  # Export and install include directory maintaining Autoware structure
-  # Always use "include" as destination (not "include/${PROJECT_NAME}")
-  # to maintain Autoware's naming convention across all ROS 2 versions
+  # Export and install include directory.
+  # When USE_SCOPED_HEADER_INSTALL_DIR is enabled, headers are installed under
+  # include/${PROJECT_NAME}. Otherwise, headers are installed under include.
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include")
-    ament_export_include_directories("include")
-    install(DIRECTORY include/ DESTINATION include
-      FILES_MATCHING
-      PATTERN "*.h"
-      PATTERN "*.hpp"
-      PATTERN "*.hh"
-      PATTERN "*.hxx"
-    )
+    if(_ARG_AUTOWARE_AMENT_AUTO_PACKAGE_USE_SCOPED_HEADER_INSTALL_DIR)
+      ament_export_include_directories("include/${PROJECT_NAME}")
+      install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME}
+        FILES_MATCHING
+        PATTERN "*.h"
+        PATTERN "*.hpp"
+        PATTERN "*.hh"
+        PATTERN "*.hxx"
+      )
+    else()
+      ament_export_include_directories("include")
+      install(DIRECTORY include/ DESTINATION include
+        FILES_MATCHING
+        PATTERN "*.h"
+        PATTERN "*.hpp"
+        PATTERN "*.hh"
+        PATTERN "*.hxx"
+      )
+    endif()
   endif()
 
   # Export and install all libraries
@@ -79,6 +90,5 @@ macro(autoware_ament_auto_package)
   endforeach()
 
   # Call ament_package with any unparsed arguments
-  set(_unparsed_args ${_ARG_AUTOWARE_AMENT_AUTO_PACKAGE_UNPARSED_ARGUMENTS})
-  ament_package(${_unparsed_args})
+  ament_package(${_ARG_AUTOWARE_AMENT_AUTO_PACKAGE_UNPARSED_ARGUMENTS})
 endmacro()

--- a/autoware_cmake/cmake/autoware_ament_auto_package.cmake
+++ b/autoware_cmake/cmake/autoware_ament_auto_package.cmake
@@ -40,20 +40,10 @@ macro(autoware_ament_auto_package)
     if(_ARG_AUTOWARE_AMENT_AUTO_PACKAGE_USE_SCOPED_HEADER_INSTALL_DIR)
       ament_export_include_directories("include/${PROJECT_NAME}")
       install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME}
-        FILES_MATCHING
-        PATTERN "*.h"
-        PATTERN "*.hpp"
-        PATTERN "*.hh"
-        PATTERN "*.hxx"
       )
     else()
       ament_export_include_directories("include")
       install(DIRECTORY include/ DESTINATION include
-        FILES_MATCHING
-        PATTERN "*.h"
-        PATTERN "*.hpp"
-        PATTERN "*.hh"
-        PATTERN "*.hxx"
       )
     endif()
   endif()


### PR DESCRIPTION
## Description

This PR updates `autoware_ament_auto_package()` to support `USE_SCOPED_HEADER_INSTALL_DIR`.

This change is based on the scoped header installation investigation for avoiding resolution against apt-installed Autoware packages and prioritizing vcs-imported source packages.

Changes:
- parse `USE_SCOPED_HEADER_INSTALL_DIR` in `cmake_parse_arguments()`
- avoid forwarding this custom argument to `ament_package()`
- install and export headers under `include/${PROJECT_NAME}` when the option is enabled
- keep the default flat `include` behavior when the option is not enabled

This fixes the configure-time error on Humble where `ament_package()` receives an unsupported argument, and also makes the scoped header install option actually functional.

## How was this PR tested?

Tested with clean build investigation using `autoware_point_types`.

Before the fix, enabling `USE_SCOPED_HEADER_INSTALL_DIR` caused:

```text
ament_package() called with unused arguments: USE_SCOPED_HEADER_INSTALL_DIR
```

After this change:
- build succeeds while keeping `USE_SCOPED_HEADER_INSTALL_DIR` enabled
- headers are installed under the scoped path as expected

## Notes for reviewers

This is the base change needed before replacing `ament_auto_package()` with `autoware_ament_auto_package()` in affected packages.

## Effects on system behavior

None, unless `USE_SCOPED_HEADER_INSTALL_DIR` is explicitly enabled.