### PR TITLE
fix: disable Eigen OpenMP parallelism to prevent callback starvation

### DIFF
--- a/autoware_cmake/cmake/autoware_package.cmake
+++ b/autoware_cmake/cmake/autoware_package.cmake
@@ -37,6 +37,10 @@ macro(autoware_package)
   # Ignore Boost deprecated messages
   add_compile_definitions(BOOST_ALLOW_DEPRECATED_HEADERS)
 
+  # PCL 1.14 propagates -fopenmp globally, causing Eigen
+  # to spin-wait with OpenMP threads and starve other callbacks.
+  add_compile_definitions(EIGEN_DONT_PARALLELIZE)
+
   # Ignore unnecessary CMake warnings
   set(__dummy__ ${CMAKE_EXPORT_COMPILE_COMMANDS})
 

--- a/autoware_cmake/cmake/autoware_package.cmake
+++ b/autoware_cmake/cmake/autoware_package.cmake
@@ -39,6 +39,7 @@ macro(autoware_package)
 
   # PCL 1.14 propagates -fopenmp globally, causing Eigen
   # to spin-wait with OpenMP threads and starve other callbacks.
+  # cspell:ignore DEIGEN DONT
   add_compile_definitions(EIGEN_DONT_PARALLELIZE)
 
   # Ignore unnecessary CMake warnings


### PR DESCRIPTION
## Description

PCL 1.14 propagates `-fopenmp` to all downstream packages via its FindOpenMP.cmake ([PR](https://github.com/PointCloudLibrary/pcl/pull/5744)). This causes Eigen to parallelize matrix multiplications using OpenMP worker threads. After each parallel region, those threads spin-wait consuming CPU, which starves other threads sharing the same process.

This was observed in `autoware_mpc_lateral_controller`: the 30ms timer callback processing time increased from ~2ms (PCL 1.12) to ~50ms (PCL 1.14) due to OpenMP worker threads competing for CPU cores.

This PR sets `EIGEN_DONT_PARALLELIZE` to restore the same behavior as Humble, where PCL 1.12 did not propagate -fopenmp and Eigen's internal OpenMP parallelism was disabled.

Adding `EIGEN_DONT_PARALLELIZE` disables Eigen's internal OpenMP parallelism. This does not affect packages that explicitly use OpenMP for their own computations (e.g., `autoware_ndt_scan_matcher`), as the macro only controls Eigen's internal thread management.

## How was this PR tested?

Verified that autoware_mpc_lateral_controller's lateral processing time returned from ~50ms to ~2ms after applying `EIGEN_DONT_PARALLELIZE`.

- `/control/trajectory_follower/controller_node_exe/lateral/debug/processing_time_ms` on Humble
  - [TIER IV internal link. Evaluator](https://evaluation.tier4.jp/evaluation/reports/fc3a0b71-92c8-5dcb-8f13-1887f23bef1a/tests/e55d7b02-0f3f-525a-8cf2-531461659b59/bc549b79-305c-5ea8-919a-7e685a7f6a77/ddf79d1e-c235-5fa7-9a9c-69eb1b497564?project_id=x2_dev)
  - <img width="1337" height="835" alt="image" src="https://github.com/user-attachments/assets/2cf48bc1-28cc-418f-ab43-f2320c36a813" />
- `/control/trajectory_follower/controller_node_exe/lateral/debug/processing_time_ms` on Jazzy
  - [TIER IV internal link. Evaluator](https://evaluation.tier4.jp/evaluation/reports/80eac846-4780-528c-bd03-01c8bdcef182/tests/5b6a8e22-cadb-538b-bb57-3f1d091d50b8/3060628e-e2f8-5d85-8f9f-5053f2809b61/2395734d-2444-5899-a42f-24370d33c95b?project_id=x2_dev)
  - <img width="1335" height="837" alt="image" src="https://github.com/user-attachments/assets/c7900ccb-2150-42a9-af5f-422fb07502f2" />
- `/control/trajectory_follower/controller_node_exe/lateral/debug/processing_time_ms` on Jazzy + this PR
  - [TIER IV internal link. Evaluator](https://evaluation.tier4.jp/evaluation/reports/d02747a9-03c3-5849-9750-20de6fc072f0/tests/6978b434-81d9-575b-b17e-6059b9f6cf31/80631a7b-8616-58f0-a71b-4381b161fdb4/aa4ea5b8-c29e-5ae1-bfdb-586bf0cfa819?project_id=x2_dev)
  - <img width="1307" height="824" alt="image" src="https://github.com/user-attachments/assets/b0463687-0dea-4edf-80ff-b751856198f0" />

(Note: The spikes at the beginning and end of the graph are due to the measurement environment and can be ignored.)

## Notes for reviewers

- This PR requires https://github.com/autowarefoundation/autoware_core/pull/1166
- `DEIGEN` and `DONT` are not general words (they are artifacts of the CMake -D prefix and a CMake macro name), so added a cspell inline ignore instead of registering them in the dictionary.
- This issue is specific to PCL 1.14+, which is shipped on ROS Humble's successor distributions (Jazzy and later). PCL 1.12.x (used on Humble) does not have this problem.
  - The propagation of -fopenmp downstream was introduced in PCL https://github.com/PointCloudLibrary/pcl/pull/5744 (merged 2023-06-12, included in PCL 1.14.0).

## Effects on system behavior

None.