### PR TITLE
feat(autoware_cmake): keep deprecated-declarations as a warning, not an error

### DIFF
--- a/autoware_cmake/cmake/autoware_package.cmake
+++ b/autoware_cmake/cmake/autoware_package.cmake
@@ -27,6 +27,8 @@ macro(autoware_package)
     else()
       add_compile_options(-Werror)
     endif()
+    # Keep deprecations as warnings so deprecated APIs can be migrated incrementally
+    add_compile_options(-Wno-error=deprecated-declarations)
   endif()
 
   # Ignore PCL errors in Clang


### PR DESCRIPTION
## Description

- Resolves #45. Follow-up to [discussion #7167](https://github.com/orgs/autowarefoundation/discussions/7167).

`autoware_package()` treats all compiler warnings as errors (via `-Werror` / `CMAKE_COMPILE_WARNING_AS_ERROR`). This means a deprecated API cannot be introduced until *every* usage across the codebase is migrated in the same change, which largely defeats the purpose of deprecations.

This adds `-Wno-error=deprecated-declarations`, demoting only `-Wdeprecated-declarations` back to a warning. All other warnings remain errors. This enables the intended workflow: add new API, deprecate old API, then migrate users incrementally.

## How was this PR tested?

Minimal CMake project with `CMAKE_COMPILE_WARNING_AS_ERROR=ON` and a `[[deprecated]]` function. The generated compile line is `... -Wno-error=deprecated-declarations ... -Werror`; the build succeeds with only a `-Wdeprecated-declarations` warning, confirming the per-warning exclusion overrides the blanket `-Werror` regardless of flag order. This covers both the CMake >= 3.24 path and the older `-Werror` path.

## Notes for reviewers

This applies the exception globally to every package using `autoware_package()` (Core + Universe), which is the behavior requested in the discussion. Other warnings are unaffected.

Demoting the error globally removes the forcing function, so deprecated APIs should be tracked (issue + target removal date) to avoid lingering indefinitely.

Context PRs that motivated this: autowarefoundation/cuda_blackboard#22, autowarefoundation/autoware_universe#12808.

## Effects on system behavior

Deprecated-declaration usages now compile with a warning instead of failing the build. No runtime behavior change.
