### PR TITLE
fix(autoware_cmake): add MSVC defaults in autoware_package

### DIFF
--- a/autoware_cmake/cmake/autoware_package.cmake
+++ b/autoware_cmake/cmake/autoware_package.cmake
@@ -75,6 +75,11 @@ macro(autoware_package)
     )
   endif()
 
+  if(MSVC)
+    add_compile_definitions(_USE_MATH_DEFINES)
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+  endif()
+
   # Find test dependencies
   if(BUILD_TESTING)
     find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
## Description

This PR is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack `patch/ros-rolling-autoware-cmake.win.patch`, authored by Daisuke Nishimatsu.

Best-guess rationale: MSVC requires `_USE_MATH_DEFINES` for math constants and needs exported symbols for shared-library consumers; setting those defaults in `autoware_package` makes Windows builds more consistent.

## How was this PR tested?

Not run locally for this upstreaming batch; relying on upstream CI.

## Notes for reviewers

Related RoboStack upstreaming tracker: https://github.com/RoboStack/robostack.github.io/issues/16

## Effects on system behavior

None.
